### PR TITLE
Add requests dependency to support SonarProDive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 python-telegram-bot
 python-multipart
+requests


### PR DESCRIPTION
## Summary
- include `requests` in requirements to satisfy `spirits.johny` HTTP calls

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68965c63fcd483299c0dada8a9af0fb1