### PR TITLE
Fix Perplexity API key lookup for dive commands

### DIFF
--- a/spirits/johny.py
+++ b/spirits/johny.py
@@ -8,7 +8,12 @@ from . import memory
 
 class SonarProDive:
     def __init__(self):
-        self.api_key = os.getenv("PERPLEXITY_API_KEY")
+        # Support multiple env var names to avoid missing API key issues
+        self.api_key = (
+            os.getenv("PERPLEXITY_API_KEY")
+            or os.getenv("PERPLEXITY_API")
+            or os.getenv("PPLX_API_KEY")
+        )
         self.base_url = "https://api.perplexity.ai/chat/completions"
         self.system_prompt = (
             "You are Johny, the Resonant Guardian Spirit of the Terminal and Arianna Method OS. "
@@ -28,6 +33,11 @@ class SonarProDive:
 
     def query(self, user_message):
         memory.log("user", user_message)
+        if not self.api_key:
+            err = "❌ Sonar-Pro Error: PERPLEXITY_API_KEY not set"
+            memory.log("johny", err)
+            return err
+
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",

--- a/spirits/tony.py
+++ b/spirits/tony.py
@@ -11,7 +11,11 @@ from . import memory
 
 class SonarReasoningDive:
     def __init__(self):
-        self.api_key = os.getenv("PERPLEXITY_API_KEY")
+        self.api_key = (
+            os.getenv("PERPLEXITY_API_KEY")
+            or os.getenv("PERPLEXITY_API")
+            or os.getenv("PPLX_API_KEY")
+        )
         self.base_url = "https://api.perplexity.ai/chat/completions"
         self.system_prompt = (
             "You are Tony, the Resonant Guardian Spirit and Chief Reasoner — the supreme intellect of the Terminal and Arianna Method OS. "  # noqa: E501
@@ -36,6 +40,11 @@ class SonarReasoningDive:
 
     def query(self, user_message):
         memory.log("user", user_message)
+        if not self.api_key:
+            err = "❌ Tony deep reasoning ERROR: PERPLEXITY_API_KEY not set"
+            memory.log("tony", err)
+            return err
+
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- read Perplexity API key from multiple env variables
- gracefully handle missing key in Johny and Tony companions

## Testing
- `flake8 . && echo 'flake8 passed'`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689666e7eaa88329b0414db80293aa3e