### PR TITLE
Add deep dive off command and persist companion chats

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -423,6 +423,9 @@ async def start_bot() -> None:
     )
     application.add_handler(run_conv)
     application.add_handler(MessageHandler(filters.ATTACHMENT, handle_file))
+    application.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, handle_telegram)
+    )
     application.add_handler(MessageHandler(filters.COMMAND, handle_telegram))
     application.add_handler(CallbackQueryHandler(handle_callback))
     await application.initialize()

--- a/letsgo.py
+++ b/letsgo.py
@@ -381,6 +381,13 @@ async def handle_diveoff(_: str) -> Tuple[str, str | None]:
     return reply, reply
 
 
+async def handle_deepdiveoff(_: str) -> Tuple[str, str | None]:
+    global COMPANION_ACTIVE
+    COMPANION_ACTIVE = None
+    reply = "Deep companion off."
+    return reply, reply
+
+
 async def handle_status(_: str) -> Tuple[str, str | None]:
     reply = status()
     return reply, color(reply, SETTINGS.green)
@@ -479,7 +486,7 @@ async def handle_help(user: str) -> Tuple[str, str | None]:
         reply = f"No help available for {cmd}"
         return reply, reply
     lines: list[str] = []
-    companion_cmds = ["/dive", "/diveoff", "/deepdive"]
+    companion_cmds = ["/dive", "/diveoff", "/deepdive", "/deepdiveoff"]
     for cmd in companion_cmds:
         if cmd in COMMAND_MAP:
             _, desc = COMMAND_MAP[cmd]
@@ -521,6 +528,7 @@ CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
     "/dive": (handle_dive, "ask companion"),
     "/diveoff": (handle_diveoff, "companion off"),
     "/deepdive": (handle_deepdive, "deep xplainer companion"),
+    "/deepdiveoff": (handle_deepdiveoff, "deep companion off"),
     "/status": (handle_status, "show system metrics"),
     "/cpu": (handle_cpu, "show CPU load"),
     "/disk": (handle_disk, "disk usage"),
@@ -540,6 +548,7 @@ COMMAND_HELP: Dict[str, str] = {
     "/dive": "Usage: /dive\nAsk companion about the last command.",
     "/diveoff": "Usage: /diveoff\nCompanion off.",
     "/deepdive": "Usage: /deepdive\nDeep xplainer companion about the last command.",
+    "/deepdiveoff": "Usage: /deepdiveoff\nDeep companion off.",
     "/status": "Usage: /status\nShow basic system metrics.",
     "/cpu": "Usage: /cpu\nShow CPU load averages.",
     "/disk": "Usage: /disk\nShow disk usage information.",
@@ -579,7 +588,7 @@ async def main() -> None:
     except FileNotFoundError:
         pass
 
-    companion_cmds = ["/dive", "/diveoff", "/deepdive"]
+    companion_cmds = ["/dive", "/diveoff", "/deepdive", "/deepdiveoff"]
     other_cmds = sorted(cmd for cmd in COMMAND_HANDLERS if cmd not in companion_cmds)
     command_summary = " ".join(companion_cmds + other_cmds)
 

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -158,14 +158,17 @@ def test_companion_commands(monkeypatch):
     assert "/dive" in commands
     assert "/deepdive" in commands
     assert "/diveoff" in commands
+    assert "/deepdiveoff" in commands
     monkeypatch.setattr(letsgo.memory, "last_user_command", lambda: "ls")
     monkeypatch.setattr(letsgo.JOHNY, "query", lambda msg: "ok")
     monkeypatch.setattr(letsgo.TONY, "query", lambda msg: "deep")
     asyncio.run(handlers["/dive"]("/dive"))
     assert letsgo.COMPANION_ACTIVE == "johny"
+    asyncio.run(handlers["/diveoff"]("/diveoff"))
+    assert letsgo.COMPANION_ACTIVE is None
     asyncio.run(handlers["/deepdive"]("/deepdive"))
     assert letsgo.COMPANION_ACTIVE == "tony"
-    asyncio.run(handlers["/diveoff"]("/diveoff"))
+    asyncio.run(handlers["/deepdiveoff"]("/deepdiveoff"))
     assert letsgo.COMPANION_ACTIVE is None
 
 
@@ -177,6 +180,7 @@ def test_help_lists_command_descriptions():
     output, _ = asyncio.run(letsgo.handle_help("/help"))
     assert "/dive" in output
     assert "ask companion" in output
+    assert "/deepdiveoff" in output
     assert "/clear" in output
     assert "clear the terminal" in output
     assert "/history" in output


### PR DESCRIPTION
## Summary
- enable Johny and Tony to continue chats by forwarding non-command text in the Telegram bridge
- add `/deepdiveoff` command and surface it in help and menus
- cover new command with tests

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689674c33cc08329b3811e92903d671d