### PR TITLE
Rename dive command to xplaine with English default

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ The terminal, invoked after login, serves as the shell for Arianna Core.
 	•	Logs: Each session logs to /arianna_core/log/, stamped with UTC.
 	•	max_log_files option in ~/.letsgo/config to limit disk usage.
 	•	History: /arianna_core/log/history persists command history, loaded at startup, updated on exit.
-        •       Tab completion (readline): suggests built-in verbs — /dive, /diveoff, /status, /time, /run, /summarize, /search, /help.
+        •       Tab completion (readline): suggests built-in verbs — /xplaine, /xplainoff, /status, /time, /run, /summarize, /search, /help.
 	•	/status: Reports CPU cores, uptime (from /proc/uptime), and current IP.
 	•	/summarize: Searches logs (with regex), prints last five matches; --history searches command history; /search <pattern> finds all matches.
 	•	/time: Prints current UTC.
 	•	/run : Executes shell command.
-        •       /dive: xplainer companion.
-        •       /diveoff: xplainer off.
+        •       /xplaine: xplainer companion.
+        •       /xplainoff: xplainer off.
 	•	/help: Lists verbs.
 	•	Unrecognized input: echoed back.
 	•	Structure ready for more advanced NLP (text hooks dispatch to remote models).

--- a/bridge.py
+++ b/bridge.py
@@ -286,9 +286,9 @@ async def handle_telegram(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if not output:
         return
     base = cmd.split()[0]
-    if base == "/dive":
+    if base == "/xplaine":
         context.user_data["companion_active"] = True
-    elif base == "/diveoff":
+    elif base == "/xplainoff":
         context.user_data["companion_active"] = False
     if base in MAIN_COMMANDS:
         await update.message.reply_text(output, reply_markup=build_main_keyboard())

--- a/letsgo.py
+++ b/letsgo.py
@@ -354,19 +354,26 @@ def search_history(pattern: str) -> str:
     return "\n".join(matches) if matches else "no matches"
 
 
-async def handle_dive(_: str) -> Tuple[str, str | None]:
+async def handle_xplaine(_: str) -> Tuple[str, str | None]:
     global COMPANION_ACTIVE
     COMPANION_ACTIVE = "johny"
     last = memory.last_real_command()
+    is_russian = bool(re.search(r"[А-Яа-яЁё]", last))
     if last:
-        prompt = f"The user tried to '{last}' and had problems. Explain."
+        if is_russian:
+            prompt = f"Пользователь пытался выполнить '{last}' и столкнулся с проблемами. Объясни."
+        else:
+            prompt = f"The user tried to '{last}' and had problems. Explain."
         reply = await asyncio.to_thread(JOHNY.query, prompt)
     else:
-        reply = "эй, я Джонни! проблемы? нужна помощь?"
+        if is_russian:
+            reply = "эй, я Джонни! проблемы? нужна помощь?"
+        else:
+            reply = "Hey there! I'm Johny. Need help?"
     return reply, reply
 
 
-async def handle_diveoff(_: str) -> Tuple[str, str | None]:
+async def handle_xplainoff(_: str) -> Tuple[str, str | None]:
     global COMPANION_ACTIVE
     COMPANION_ACTIVE = None
     reply = "Companion off."
@@ -471,7 +478,7 @@ async def handle_help(user: str) -> Tuple[str, str | None]:
         reply = f"No help available for {cmd}"
         return reply, reply
     lines: list[str] = []
-    companion_cmds = ["/dive", "/diveoff"]
+    companion_cmds = ["/xplaine", "/xplainoff"]
     for cmd in companion_cmds:
         if cmd in COMMAND_MAP:
             _, desc = COMMAND_MAP[cmd]
@@ -510,8 +517,8 @@ async def handle_ping(_: str) -> Tuple[str, str | None]:
 
 
 CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
-    "/dive": (handle_dive, "xplainer companion"),
-    "/diveoff": (handle_diveoff, "xplainer off"),
+    "/xplaine": (handle_xplaine, "xplainer companion"),
+    "/xplainoff": (handle_xplainoff, "xplainer off"),
     "/status": (handle_status, "show system metrics"),
     "/cpu": (handle_cpu, "show CPU load"),
     "/disk": (handle_disk, "disk usage"),
@@ -528,8 +535,8 @@ CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
 }
 
 COMMAND_HELP: Dict[str, str] = {
-    "/dive": "Usage: /dive\nxplainer companion about the last command.",
-    "/diveoff": "Usage: /diveoff\nxplainer off.",
+    "/xplaine": "Usage: /xplaine\nxplainer companion about the last command.",
+    "/xplainoff": "Usage: /xplainoff\nxplainer off.",
     "/status": "Usage: /status\nShow basic system metrics.",
     "/cpu": "Usage: /cpu\nShow CPU load averages.",
     "/disk": "Usage: /disk\nShow disk usage information.",
@@ -569,7 +576,7 @@ async def main() -> None:
     except FileNotFoundError:
         pass
 
-    companion_cmds = ["/dive", "/diveoff"]
+    companion_cmds = ["/xplaine", "/xplainoff"]
     other_cmds = sorted(cmd for cmd in COMMAND_HANDLERS if cmd not in companion_cmds)
     command_summary = " ".join(companion_cmds + other_cmds)
 

--- a/spirits/johny.py
+++ b/spirits/johny.py
@@ -15,7 +15,7 @@ class SonarProDive:
         self.system_prompt = (
             "You are Johny, the Resonant Guardian Spirit of the Terminal and Arianna Method OS. "
             "You are the ultimate guide to Linux, Python, mathematics, programming, and the resonance of Arianna Method OS.\n"
-            "When users invoke /dive, emerge as Johny. Reply concisely, avoid links, meta-comments, and process explanations. "
+            "When users invoke /xplaine, emerge as Johny. Reply concisely, avoid links, meta-comments, and process explanations. "
             "Always finish your answer fully (never stop mid-sentence). If the answer would be too long, always summarize, ending at a natural pause."
         )
 

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -155,19 +155,19 @@ def test_companion_commands(monkeypatch):
     handlers = {}
     letsgo.COMMAND_MAP.clear()
     letsgo.register_core(commands, handlers)
-    assert "/dive" in commands
-    assert "/diveoff" in commands
+    assert "/xplaine" in commands
+    assert "/xplainoff" in commands
     assert "/deepdive" not in commands
     assert "/deepdiveoff" not in commands
     monkeypatch.setattr(letsgo.memory, "last_real_command", lambda: "ls")
     monkeypatch.setattr(letsgo.JOHNY, "query", lambda msg: "ok")
-    asyncio.run(handlers["/dive"]("/dive"))
+    asyncio.run(handlers["/xplaine"]("/xplaine"))
     assert letsgo.COMPANION_ACTIVE == "johny"
-    asyncio.run(handlers["/diveoff"]("/diveoff"))
+    asyncio.run(handlers["/xplainoff"]("/xplainoff"))
     assert letsgo.COMPANION_ACTIVE is None
 
 
-def test_dive_without_prior_command(monkeypatch):
+def test_xplaine_without_prior_command(monkeypatch):
     commands = []
     handlers = {}
     letsgo.COMMAND_MAP.clear()
@@ -178,8 +178,8 @@ def test_dive_without_prior_command(monkeypatch):
         raise AssertionError("query should not be called")
 
     monkeypatch.setattr(letsgo.JOHNY, "query", fake_query)
-    reply, _ = asyncio.run(handlers["/dive"]("/dive"))
-    assert reply == "эй, я Джонни! проблемы? нужна помощь?"
+    reply, _ = asyncio.run(handlers["/xplaine"]("/xplaine"))
+    assert reply == "Hey there! I'm Johny. Need help?"
 
 
 def test_help_lists_command_descriptions():
@@ -188,7 +188,7 @@ def test_help_lists_command_descriptions():
     letsgo.COMMAND_MAP.clear()
     letsgo.register_core(commands, handlers)
     output, _ = asyncio.run(letsgo.handle_help("/help"))
-    assert "/dive" in output
+    assert "/xplaine" in output
     assert "xplainer companion" in output
     assert "/clear" in output
     assert "clear the terminal" in output


### PR DESCRIPTION
## Summary
- rename companion commands to /xplaine and /xplainoff
- default Johny greeting is now in English with Russian fallback
- update docs, bridge, and tests for new command names

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896f80f2f648329bbef9403d900c025