### PR TITLE
Rename /xplainoff command to /xplaineoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ The terminal, invoked after login, serves as the shell for Arianna Core.
 	•	Logs: Each session logs to /arianna_core/log/, stamped with UTC.
 	•	max_log_files option in ~/.letsgo/config to limit disk usage.
 	•	History: /arianna_core/log/history persists command history, loaded at startup, updated on exit.
-        •       Tab completion (readline): suggests built-in verbs — /xplaine, /xplainoff, /status, /time, /run, /summarize, /search, /help.
+        •       Tab completion (readline): suggests built-in verbs — /xplaine, /xplaineoff, /status, /time, /run, /summarize, /search, /help.
 	•	/status: Reports CPU cores, uptime (from /proc/uptime), and current IP.
 	•	/summarize: Searches logs (with regex), prints last five matches; --history searches command history; /search <pattern> finds all matches.
 	•	/time: Prints current UTC.
 	•	/run : Executes shell command.
         •       /xplaine: xplainer companion.
-        •       /xplainoff: xplainer off.
+        •       /xplaineoff: xplainer off.
 	•	/help: Lists verbs.
 	•	Unrecognized input: echoed back.
 	•	Structure ready for more advanced NLP (text hooks dispatch to remote models).

--- a/bridge.py
+++ b/bridge.py
@@ -288,7 +288,7 @@ async def handle_telegram(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     base = cmd.split()[0]
     if base == "/xplaine":
         context.user_data["companion_active"] = True
-    elif base == "/xplainoff":
+    elif base == "/xplaineoff":
         context.user_data["companion_active"] = False
     if base in MAIN_COMMANDS:
         await update.message.reply_text(output, reply_markup=build_main_keyboard())

--- a/letsgo.py
+++ b/letsgo.py
@@ -373,7 +373,7 @@ async def handle_xplaine(_: str) -> Tuple[str, str | None]:
     return reply, reply
 
 
-async def handle_xplainoff(_: str) -> Tuple[str, str | None]:
+async def handle_xplaineoff(_: str) -> Tuple[str, str | None]:
     global COMPANION_ACTIVE
     COMPANION_ACTIVE = None
     reply = "Companion off."
@@ -478,7 +478,7 @@ async def handle_help(user: str) -> Tuple[str, str | None]:
         reply = f"No help available for {cmd}"
         return reply, reply
     lines: list[str] = []
-    companion_cmds = ["/xplaine", "/xplainoff"]
+    companion_cmds = ["/xplaine", "/xplaineoff"]
     for cmd in companion_cmds:
         if cmd in COMMAND_MAP:
             _, desc = COMMAND_MAP[cmd]
@@ -518,7 +518,7 @@ async def handle_ping(_: str) -> Tuple[str, str | None]:
 
 CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
     "/xplaine": (handle_xplaine, "xplainer companion"),
-    "/xplainoff": (handle_xplainoff, "xplainer off"),
+    "/xplaineoff": (handle_xplaineoff, "xplainer off"),
     "/status": (handle_status, "show system metrics"),
     "/cpu": (handle_cpu, "show CPU load"),
     "/disk": (handle_disk, "disk usage"),
@@ -536,7 +536,7 @@ CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
 
 COMMAND_HELP: Dict[str, str] = {
     "/xplaine": "Usage: /xplaine\nxplainer companion about the last command.",
-    "/xplainoff": "Usage: /xplainoff\nxplainer off.",
+    "/xplaineoff": "Usage: /xplaineoff\nxplainer off.",
     "/status": "Usage: /status\nShow basic system metrics.",
     "/cpu": "Usage: /cpu\nShow CPU load averages.",
     "/disk": "Usage: /disk\nShow disk usage information.",
@@ -576,7 +576,7 @@ async def main() -> None:
     except FileNotFoundError:
         pass
 
-    companion_cmds = ["/xplaine", "/xplainoff"]
+    companion_cmds = ["/xplaine", "/xplaineoff"]
     other_cmds = sorted(cmd for cmd in COMMAND_HANDLERS if cmd not in companion_cmds)
     command_summary = " ".join(companion_cmds + other_cmds)
 

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -156,14 +156,14 @@ def test_companion_commands(monkeypatch):
     letsgo.COMMAND_MAP.clear()
     letsgo.register_core(commands, handlers)
     assert "/xplaine" in commands
-    assert "/xplainoff" in commands
+    assert "/xplaineoff" in commands
     assert "/deepdive" not in commands
     assert "/deepdiveoff" not in commands
     monkeypatch.setattr(letsgo.memory, "last_real_command", lambda: "ls")
     monkeypatch.setattr(letsgo.JOHNY, "query", lambda msg: "ok")
     asyncio.run(handlers["/xplaine"]("/xplaine"))
     assert letsgo.COMPANION_ACTIVE == "johny"
-    asyncio.run(handlers["/xplainoff"]("/xplainoff"))
+    asyncio.run(handlers["/xplaineoff"]("/xplaineoff"))
     assert letsgo.COMPANION_ACTIVE is None
 
 


### PR DESCRIPTION
## Summary
- rename `/xplainoff` command and handler to `/xplaineoff`
- update documentation and tests for new `/xplaineoff` command

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896fdbcdb9083298f1599dcacf28f55