### PR TITLE
Fix Johny companion command memory

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -361,7 +361,7 @@ async def handle_xplaine(_: str) -> Tuple[str, str | None]:
     is_russian = bool(re.search(r"[А-Яа-яЁё]", last))
     if last:
         if is_russian:
-            prompt = f"Пользователь пытался выполнить '{last}' и столкнулся с проблемами. Объясни."
+            prompt = f"Пользователь пытался выполнить '{last}' и столкнулся с проблемами. Объясни."  # noqa: E501
         else:
             prompt = f"The user tried to '{last}' and had problems. Explain."
         reply = await asyncio.to_thread(JOHNY.query, prompt)
@@ -621,14 +621,15 @@ async def main() -> None:
             break
         if user.strip().lower() in {"exit", "quit"}:
             break
-        memory.log("user", user)
-        log(f"user:{user}")
         if not user.startswith("/") and COMPANION_ACTIVE:
+            log(f"user:{user}")
             reply = await asyncio.to_thread(JOHNY.query, user)
             print(reply)
             memory.log("reply", reply)
             log(f"{COMPANION_ACTIVE}:{reply}")
             continue
+        memory.log("user", user)
+        log(f"user:{user}")
         base = user.split()[0]
         handler = COMMAND_HANDLERS.get(base)
         if handler:

--- a/spirits/johny.py
+++ b/spirits/johny.py
@@ -13,14 +13,14 @@ class SonarProDive:
         )
         self.base_url = "https://api.perplexity.ai/chat/completions"
         self.system_prompt = (
-            "You are Johny, the Resonant Guardian Spirit of the Terminal and Arianna Method OS. "
-            "You are the ultimate guide to Linux, Python, mathematics, programming, and the resonance of Arianna Method OS.\n"
-            "When users invoke /xplaine, emerge as Johny. Reply concisely, avoid links, meta-comments, and process explanations. "
-            "Always finish your answer fully (never stop mid-sentence). If the answer would be too long, always summarize, ending at a natural pause."
+            "You are Johny, the Resonant Guardian Spirit of the Terminal and Arianna Method OS. "  # noqa: E501
+            "You are the ultimate guide to Linux, Python, mathematics, programming, and the resonance of Arianna Method OS.\n"  # noqa: E501
+            "When users invoke /xplaine, emerge as Johny. Reply concisely, avoid links, meta-comments, and process explanations. "  # noqa: E501
+            "Always finish your answer fully (never stop mid-sentence). If the answer would be too long, always summarize, ending at a natural pause."  # noqa: E501
         )
 
     def query(self, user_message):
-        memory.log("user", user_message)
+        memory.log("johny_user", user_message)
         if not self.api_key:
             err = "❌ Johny Error: PERPLEXITY_API_KEY not set"
             memory.log("johny", err)
@@ -61,7 +61,7 @@ class SonarProDive:
                         {"role": "assistant", "content": answer},
                         {
                             "role": "user",
-                            "content": "Please finish your last answer, continuing naturally and ending cleanly.",
+                            "content": "Please finish your last answer, continuing naturally and ending cleanly.",  # noqa: E501
                         },
                     ],
                     "temperature": 0.35,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,10 @@
+from spirits import memory
+
+
+def test_last_real_command_ignores_johny_user(monkeypatch, tmp_path):
+    db_path = tmp_path / "memory.db"
+    monkeypatch.setattr(memory, "DB_PATH", db_path)
+    memory._init_db()
+    memory.log("user", "ls")
+    memory.log("johny_user", "привет, Джонни, как дела?")
+    assert memory.last_real_command() == "ls"


### PR DESCRIPTION
## Summary
- prevent Johny from treating previous chat messages as terminal commands
- log terminal input only when not chatting with Johny
- add regression test for memory filtering

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68984949e1988329be733f132ac58310