### PR TITLE
Fix help command parsing

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -471,7 +471,7 @@ async def handle_history(user: str) -> Tuple[str, str | None]:
 async def handle_help(user: str) -> Tuple[str, str | None]:
     parts = user.split(maxsplit=1)
     if len(parts) > 1:
-        cmd = parts[1]
+        cmd = parts[1].split()[0]
         help_text = COMMAND_HELP.get(cmd)
         if help_text:
             return help_text, help_text

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -205,6 +205,15 @@ def test_help_specific_command():
     assert "Usage: /time" in output
 
 
+def test_help_ignores_extra_args():
+    commands = []
+    handlers = {}
+    letsgo.COMMAND_MAP.clear()
+    letsgo.register_core(commands, handlers)
+    output, _ = asyncio.run(letsgo.handle_help("/help /time extra"))
+    assert "Usage: /time" in output
+
+
 def test_help_unknown_command():
     output, _ = asyncio.run(letsgo.handle_help("/help /missing"))
     assert "No help available for /missing" in output


### PR DESCRIPTION
## Summary
- ensure /help considers only the first argument, ignoring extra text
- test /help parsing for additional arguments

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68997f4bffc883299cea55bddacf6c6f