### PR TITLE
Ensure /help always lists main commands

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -470,13 +470,6 @@ async def handle_history(user: str) -> Tuple[str, str | None]:
 
 async def handle_help(user: str) -> Tuple[str, str | None]:
     parts = user.split(maxsplit=1)
-    if len(parts) > 1:
-        cmd = parts[1].split()[0]
-        help_text = COMMAND_HELP.get(cmd)
-        if help_text:
-            return help_text, help_text
-        reply = f"No help available for {cmd}"
-        return reply, reply
     lines: list[str] = []
     companion_cmds = ["/xplaine", "/xplaineoff"]
     for cmd in companion_cmds:
@@ -486,6 +479,15 @@ async def handle_help(user: str) -> Tuple[str, str | None]:
     for cmd, (_, desc) in sorted(COMMAND_MAP.items()):
         if cmd not in companion_cmds:
             lines.append(f"{cmd} - {desc}")
+    if len(parts) > 1:
+        cmd = parts[1].split()[0]
+        help_text = COMMAND_HELP.get(cmd)
+        if help_text:
+            lines.append("")
+            lines.append(help_text)
+        else:
+            lines.append("")
+            lines.append(f"No help available for {cmd}")
     reply = "\n".join(lines)
     return reply, reply
 

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -202,6 +202,7 @@ def test_help_specific_command():
     letsgo.COMMAND_MAP.clear()
     letsgo.register_core(commands, handlers)
     output, _ = asyncio.run(letsgo.handle_help("/help /time"))
+    assert "/xplaine" in output
     assert "Usage: /time" in output
 
 
@@ -211,11 +212,13 @@ def test_help_ignores_extra_args():
     letsgo.COMMAND_MAP.clear()
     letsgo.register_core(commands, handlers)
     output, _ = asyncio.run(letsgo.handle_help("/help /time extra"))
+    assert "/xplaine" in output
     assert "Usage: /time" in output
 
 
 def test_help_unknown_command():
     output, _ = asyncio.run(letsgo.handle_help("/help /missing"))
+    assert "/xplaine" in output
     assert "No help available for /missing" in output
 
 


### PR DESCRIPTION
## Summary
- always include the main command list in `/help` output
- update tests for `/help` with arguments

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689986f13654832996cd87ba59d8a93c