### PR TITLE
Align /help with /start command output

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -367,12 +367,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    cmd = "/help"
-    if context.args:
-        cmd += " " + " ".join(context.args)
-    if update.message:
-        update.message.text = cmd
-    await handle_telegram(update, context)
+    await start(update, context)
 
 
 async def history_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- Ensure `/help` invokes the same handler as `/start`, so both show the main commands list and keyboard.

## Testing
- `flake8 bridge.py tests`
- `black --check bridge.py tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899b1722f3483299165d85df936ea5e