### PR TITLE
feat: auto format python and expand shell support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+black
 fastapi
 uvicorn[standard]
-python-telegram-bot
-python-multipart
+python - telegram - bot
+python - multipart
 requests


### PR DESCRIPTION
## Summary
- auto-detect Python code in plain messages and format with black
- run plain messages as shell commands when not Python
- add black as runtime dependency

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8fc9770f083299efca8d1e0a994bf