### PR TITLE
Fix dependency names in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black
 fastapi
 uvicorn[standard]
-python - telegram - bot
-python - multipart
+python-telegram-bot
+python-multipart
 requests


### PR DESCRIPTION
## Summary
- correct dependency names for python-telegram-bot and python-multipart

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b197775c94832996d938a191e8616e